### PR TITLE
Don't crash under Python 3 which has the new __qualname__

### DIFF
--- a/marrow/interface/core.py
+++ b/marrow/interface/core.py
@@ -7,7 +7,8 @@ from marrow.interface.schema import Attribute
 
 __all__ = ['InterfaceMeta', 'Interface']
 
-ALLOWED_PROPERTIES = ('__doc__', '__module__', '__assume_interface__')
+ALLOWED_PROPERTIES = ('__doc__', '__module__', '__assume_interface__',
+    '__qualname__')
 
 
 class InterfaceMeta(type):
@@ -16,61 +17,63 @@ class InterfaceMeta(type):
         if len(bases) == 1 and bases[0] is object:
             attrs['__abstract__'] = dict()
             return type.__new__(meta, name, bases, attrs)
-        
+
         abstract = dict()
-        
+
         for key in attrs:
             if key in ALLOWED_PROPERTIES:
                 continue
-            
+
             value = attrs[key]
-            
+
             if not isinstance(value, Attribute):
-                raise TypeError("Interfaces must only contain Attribute instances, not a %s named %s." % (
-                    type(value).__name__, key))
-            
+                raise TypeError("Interfaces must only contain Attribute "
+                    "instances, not a %s named %s." % (
+                        type(value).__name__, key))
+
             if value.name is None:
                 value.name = key
-            
+
             abstract[key] = value
-        
+
         for base in bases:
             if type(base) is not InterfaceMeta:
-                raise TypeError("Do not mix interfaces with other base classes.")
-            
+                raise TypeError(
+                    "Do not mix interfaces with other base classes.")
+
             collision = set(abstract) & set(base.__dict__['__abstract__'])
-            
+
             if collision:
                 raise TypeError("Conflicting interfaces, %s redefines: %s" % (
                         base.__name__, ', '.join(collision)))
-            
+
             abstract.update(base.__dict__['__abstract__'])
-        
+
         attrs['__abstract__'] = abstract
-        
+
         return type.__new__(meta, name, bases, attrs)
-    
+
     def __instancecheck__(cls, inst, live=True):
         """Does the given instance support this interface?"""
         return cls.implements(inst)
-    
+
     def implements(interface, instance):
         assumptions = interface.__dict__.get('__assume_interface__', [])
-        
+
         if inspect.isclass(instance):
             for assumption in assumptions:
                 if issubclass(instance, assumption):
                     return True
-        
+
         else:
             for assumption in assumptions:
                 if isinstance(instance, assumption):
                     return True
-        
+
         for i, j in interface.__abstract__.items():
             if not j(instance):
                 return False
-        
+
         return True
 
 

--- a/setup.py
+++ b/setup.py
@@ -10,36 +10,36 @@ from setuptools import setup, find_packages
 if sys.version_info < (2, 6):
     raise SystemExit("Python 2.6 or later is required.")
 
-exec(open(os.path.join("marrow", "interface", "release.py")))
+exec(open(os.path.join("marrow", "interface", "release.py")).read())
 
 
 
 setup(
         name = "marrow.interface",
         version = version,
-        
+
         description = "An anti-Pythonic declarative strict interface definition and validation system.",
         long_description = """\
 For full documentation, see the README.textile file present in the package,
 or view it online on the GitHub project page:
 
 https://github.com/marrow/marrow.interface""",
-        
+
         author = "Alice Bevan-McGregor",
         author_email = "alice+marrow@gothcandy.com",
         url = "https://github.com/marrow/marrow.interface",
         license = "MIT",
-        
+
         install_requires = [
             'marrow.util < 2.0'
         ],
-        
+
         test_suite = 'nose.collector',
         tests_require = [
             'nose',
             'coverage'
         ],
-        
+
         classifiers = [
             "Development Status :: 5 - Production/Stable",
             "Environment :: Console",
@@ -54,11 +54,11 @@ https://github.com/marrow/marrow.interface""",
             "Programming Language :: Python :: 3.2",
             "Topic :: Software Development :: Libraries :: Python Modules"
         ],
-        
+
         packages = find_packages(exclude=['examples', 'tests']),
         zip_safe = True,
         include_package_data = True,
         package_data = {'': ['README.textile', 'LICENSE']},
-        
+
         namespace_packages = ['marrow'],
     )


### PR DESCRIPTION
Also fixed a problem in setup.py; couldn't _setup.py develop_
under Python 3.3 alpha 1.
